### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ You need a few things for this to work properly:
 
 ## puma-dev
 
-- install with `brew install puma-dev`
-- run `sudo puma-dev setup` so it can resolve domains for you
+- install with `brew install puma/puma/puma-dev`
+- run `sudo puma-dev -setup` so it can resolve domains for you
 - run `puma-dev -install`
 - You need to trust puma-dev's certificate. Open the certificate file, `~/Library/Application\ Support/io.puma.dev/cert.pem`, in Keychain Access. Right-click on the certificate from inside Keychain Access, click "Get Info", uncollapse the "Trust" section, then change the settings for "Secure Sockets Layer (SSL)" and "X.509 Basic Policy" to "Always Trust". Close the "Get Info" window, and you will be prompted to enter your administrator password. Once you do that, it should be trusted, at least in Chrome.
 - To trust it in Firefox, go to `about:config` and change the setting `security.enterprise_roots.enabled` to `true`. This will make Firefox trust your system certificates.


### PR DESCRIPTION
The readme instructions on setting up the puma dev server are incorrect.

1. Running `brew install puma-dev` causes the following error: `Error: No available formula with the name "puma-dev"`
- Instead you should run `brew install puma/puma/puma-dev` as per https://github.com/puma/puma-dev

2. `sudo puma-dev setup` is also invalid

```bash
$ sudo puma-dev setup
Error: Unknown command: setup
```

You need to include the hyphen: sudo puma-dev -setup

Just to make sure people don't waste time on silly mistakes like this 👍